### PR TITLE
Use internal IPs to connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ func main() {
 	}
     // Set the address translator for this cluster to our ComposeAddressTranslator
 	cluster.AddressTranslator = cat
+	// This seems to be necessary to avoid gocql attempting to fetch info from cluster about 
+	// the seed node's external IP which fails with a warning.
+	cluster.IgnorePeerAddr = true
 
     cluster.Keyspace = "test"
 	session, err := cluster.CreateSession()

--- a/cat.go
+++ b/cat.go
@@ -72,7 +72,7 @@ func (cat ComposeAddressTranslator) ContactPoints() []string {
 	s := make([]string, len(cat.Map))
 	i := 0
 	// Return the _internal_ IP addresses as gocql seems to expect these
-	for h, _ := range cat.Map {
+	for h := range cat.Map {
 		s[i] = h
 		i++
 	}

--- a/cat.go
+++ b/cat.go
@@ -71,7 +71,8 @@ func (cat ComposeAddressTranslator) Translate(addr net.IP, port int) (net.IP, in
 func (cat ComposeAddressTranslator) ContactPoints() []string {
 	s := make([]string, len(cat.Map))
 	i := 0
-	for _, h := range cat.Map {
+	// Return the _internal_ IP addresses as gocql seems to expect these
+	for h, _ := range cat.Map {
 		s[i] = h
 		i++
 	}

--- a/cat_test.go
+++ b/cat_test.go
@@ -52,8 +52,8 @@ func TestContactPoints(t *testing.T) {
 		"127.0.0.1:2": "192.168.1.1:3",
 	}}.ContactPoints()
 	want := []string{
-		"192.168.1.1:1",
-		"192.168.1.1:3",
+		"127.0.0.1:0",
+		"127.0.0.1:2",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got: %v, wanted: %v", got, want)


### PR DESCRIPTION
The Hosts passed are translated anyway, this creates fewer confusing host entries in the client.

Also update README to suggest flag that suppresses confusing warnings.